### PR TITLE
Update GitHub Action to Python 3.11

### DIFF
--- a/.github/workflows/update-russell1000.yml
+++ b/.github/workflows/update-russell1000.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.11'
         
     - name: Install dependencies
       run: |


### PR DESCRIPTION
- Upgrade from Python 3.9 to 3.11 for pytest 9.0.2 compatibility
- pytest 9.0.2 requires Python >=3.10
- Python 3.9 reached EOL in October 2025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build environment to use Python 3.11 for enhanced compatibility and performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->